### PR TITLE
Add script for easily getting 3 files from golden tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ tests/support/package-lock.json
 tags
 TAGS
 
+# Gather source map files from golden tests
+.source-maps
+
 # Profiling related
 *.aux
 *.hp

--- a/get-source-maps.sh
+++ b/get-source-maps.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+TEST_MODULES_DIR=.test_modules
+OUTPUT_DIR=.source-maps
+
+if [ ! -d "$TEST_MODULES_DIR" ]; then
+  echo "'$TEST_MODULES_DIR' dir does not exist. You need to run 'stack test --fast --ta \"match sourcemaps\"' first"
+  exit 1
+fi
+
+if [ -d "$OUTPUT_DIR" ]; then
+  echo "Removing $OUTPUT_DIR"
+  rm -rf "$OUTPUT_DIR"
+fi
+
+echo "Getting source maps"
+
+mkdir -p "$OUTPUT_DIR"
+
+while IFS= read -r -d '' file
+do
+  MODULE="$(basename "$file" .purs)"
+  echo "Copying files for $MODULE"
+  mkdir -p "$OUTPUT_DIR/$MODULE"
+  cp -r \
+    "$TEST_MODULES_DIR/SourceMaps.$MODULE/index.js" \
+    "$TEST_MODULES_DIR/SourceMaps.$MODULE/index.js.map" \
+    "$OUTPUT_DIR/$MODULE/"
+  cp "$file" "$OUTPUT_DIR/$MODULE/$MODULE.purs"
+done <   <(find "tests/purs/sourcemaps" -type f -wholename '*.purs' -print0)

--- a/tests/TestSourceMaps.hs
+++ b/tests/TestSourceMaps.hs
@@ -35,7 +35,14 @@ assertCompilesToExpectedOutput support inputFiles = do
   (result, _) <- compile' compilationOptions False support inputFiles
   case result of
     Left errs -> expectationFailure . P.prettyPrintMultipleErrors P.defaultPPEOptions $ errs
-    Right _ ->
+    Right _ -> do
+      let
+        modulePath = getTestMain inputFiles
+        strLength = length :: String -> Int
+        dirPrefix = strLength "tests/purs/sourcemaps/"
+        moduleSuffix = do
+          let modulePlusExt = drop dirPrefix modulePath
+          take (strLength modulePlusExt - strLength ".purs") modulePlusExt
       goldenVsString
-        (replaceExtension (getTestMain inputFiles) ".out.js.map")
-        (BS.readFile $ modulesDir </> "Main/index.js.map")
+        (replaceExtension modulePath ".out.js.map")
+        (BS.readFile $ modulesDir </> "SourceMaps." <> moduleSuffix <> "/index.js.map")

--- a/tests/purs/sourcemaps/3851.out.js.map
+++ b/tests/purs/sourcemaps/3851.out.js.map
@@ -1,1 +1,0 @@
-{"mappings":"AAAA;AAKA;AAOA,gBACO;AANP;;QACI;mBAAM;;QACJ;mBAAI;;eACA,IAAI,KAAJ;;;AAKV;IAGE,UAAO,SAAU,kCADT;IAER,UAAK;IAED,QAAI,IAAI,GAAI,IAAI,IAAG;IACvB,mBAAM,SAAU,kCAAK;IACrB,mBAAa,SAAS,kCAAK;WAC3B,mBAAI","sources":["../../tests/purs/sourcemaps/3851.purs"],"names":[],"version":3,"file":"index.js"}

--- a/tests/purs/sourcemaps/Binders.purs
+++ b/tests/purs/sourcemaps/Binders.purs
@@ -1,4 +1,4 @@
-module Main where
+module SourceMaps.Binders where
 
 import Prelude
 import Effect (Effect)

--- a/tests/purs/sourcemaps/Bug3581.out.js.map
+++ b/tests/purs/sourcemaps/Bug3581.out.js.map
@@ -1,0 +1,1 @@
+{"mappings":"AAAA;AAKA;AAOA,gBACO;AANP;;QACI;mBAAM;;QACJ;mBAAI;;eACA,IAAI,KAAJ;;;AAKV;IAGE,UAAO,SAAU,kCADT;IAER,UAAK;IAED,QAAI,IAAI,GAAI,IAAI,IAAG;IACvB,mBAAM,SAAU,kCAAK;IACrB,mBAAa,SAAS,kCAAK;WAC3B,mBAAI","sources":["../../tests/purs/sourcemaps/Bug3581.purs"],"names":[],"version":3,"file":"index.js"}

--- a/tests/purs/sourcemaps/Bug3581.purs
+++ b/tests/purs/sourcemaps/Bug3581.purs
@@ -1,4 +1,4 @@
-module Main where
+module SourceMaps.Bug3581 where
 
 import Prelude
 

--- a/tests/purs/sourcemaps/Expr.purs
+++ b/tests/purs/sourcemaps/Expr.purs
@@ -1,4 +1,4 @@
-module Main where
+module SourceMaps.Expr where
 
 import Prelude
 import Effect (Effect)


### PR DESCRIPTION
**Description of the change**

Getting the 3 files from golden tests was tedious because the outputted JS file isn't easily accessible. I don't think this is necessarily the best way to handle this problem, but it sufficed for my purposes. 

Workflow:
```sh
stack test --fast --ta "--match sourcemaps"
./get-source-maps.sh
# upload the 3 files in .source-maps/MODULE_NAME/
```